### PR TITLE
[Feature] 디렉토리로 노트를 묶는 기능 개발 

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -60,13 +60,11 @@ function copyFilesToBuild() {
 	// manifest.json 복사
 	if (existsSync("manifest.json")) {
 		copyFileSync("manifest.json", "build/manifest.json");
-		console.log("✅ manifest.json copied to build/");
 	}
 
 	// styles.css 복사
 	if (existsSync("styles.css")) {
 		copyFileSync("styles.css", "build/styles.css");
-		console.log("✅ styles.css copied to build/");
 	}
 }
 
@@ -75,7 +73,6 @@ function copyToPluginFolder() {
 	// 플러그인 폴더가 없으면 생성
 	if (!existsSync(PLUGIN_PATH)) {
 		mkdirSync(PLUGIN_PATH, { recursive: true });
-		console.log(`📁 Created plugin folder: ${PLUGIN_PATH}`);
 	}
 
 	// build 폴더의 모든 파일을 플러그인 폴더로 복사
@@ -87,23 +84,14 @@ function copyToPluginFolder() {
 		
 		if (existsSync(sourcePath)) {
 			copyFileSync(sourcePath, targetPath);
-			console.log(`✅ ${file} copied to plugin folder`);
-		} else {
-			console.log(`⚠️  ${file} not found in build folder`);
 		}
 	});
-	
-	console.log(`🎉 All files copied to: ${PLUGIN_PATH}`);
 }
 
 if (prod) {
 	await context.rebuild();
 	copyFilesToBuild();
 	copyToPluginFolder();
-	console.log("🎉 Build completed! Files generated in build/ folder and copied to plugin folder:");
-	console.log("   - main.js");
-	console.log("   - manifest.json");
-	console.log("   - styles.css");
 	process.exit(0);
 } else {
 	await context.watch();

--- a/src/components/AllCardsComponent.tsx
+++ b/src/components/AllCardsComponent.tsx
@@ -1,4 +1,3 @@
-import { h } from 'preact';
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { MarkdownRenderer, App, Component } from 'obsidian';
 import { ITEMS_PER_PAGE } from '../types';
@@ -100,8 +99,8 @@ export function AllCardsComponent({
   
   // 전체 카드 통계 (현재 페이지가 아닌 전체)
   const total = allCards.length;
-  const reviewed = allCards.filter((c: any) => c.reviewed).length;
-  const unreviewed = allCards.filter((c: any) => !c.reviewed).length;
+  const reviewed = allCards.filter((c: CardData) => c.reviewed).length;
+  const unreviewed = allCards.filter((c: CardData) => !c.reviewed).length;
 
   // 디렉토리 사전과 선택된 디렉토리의 소스 사전 만들기
   const directories = useMemo(() => {
@@ -136,9 +135,9 @@ export function AllCardsComponent({
     const handleMoveComplete = () => {
       setRefreshTrigger(prev => prev + 1);
     };
-    
-    window.addEventListener('card-review-move-complete' as any, handleMoveComplete);
-    return () => window.removeEventListener('card-review-move-complete' as any, handleMoveComplete);
+
+    window.addEventListener('card-review-move-complete', handleMoveComplete);
+    return () => window.removeEventListener('card-review-move-complete', handleMoveComplete);
   }, [selectedDirectory]);
 
   const handleResetAllCards = async () => {
@@ -190,15 +189,15 @@ export function AllCardsComponent({
           <div
             class={`directory-tile ${dir === selectedDirectory ? 'all-cards' : ''}`}
             style="cursor: pointer; pointer-events: auto;"
-            onClick={(e: any) => { 
+            onClick={(e: MouseEvent) => { 
               e.preventDefault();
               e.stopPropagation();
               onDirectorySelect(dir);
             }}
-            onDragOver={(e: any) => { e.preventDefault(); }}
-            onDrop={(e: any) => {
+            onDragOver={(e: DragEvent) => { e.preventDefault(); }}
+            onDrop={(e: DragEvent) => {
               try {
-                const data = e.dataTransfer.getData('text/plain');
+                const data = e.dataTransfer?.getData('text/plain');
                 if (!data) return;
                 // data에는 source 경로가 들어온다고 가정
                 const payload = JSON.parse(data);
@@ -207,12 +206,14 @@ export function AllCardsComponent({
                   const ev = new CustomEvent('card-review-move-source', { detail: { source: payload.source, dir } });
                   window.dispatchEvent(ev);
                 }
-              } catch {}
+              } catch(error) {
+                console.error('디렉토리 이동 오류:', error);
+				}
             }}
           >
             <div 
               class="directory-title"
-              onClick={(e: any) => { 
+              onClick={(e: MouseEvent) => { 
                 e.preventDefault();
                 e.stopPropagation();
                 onDirectorySelect(dir);

--- a/src/components/AllCardsComponent.tsx
+++ b/src/components/AllCardsComponent.tsx
@@ -247,7 +247,11 @@ export function AllCardsComponent({
                 <button 
                   class="pagination-btn"
                   disabled={localPage === 0}
-                  onClick={() => { setLocalPage(p => Math.max(0, p - 1)); onPageChange(localPage - 1); }}
+                  onClick={() => setLocalPage(p => {
+                    const newPage = Math.max(0, p - 1);
+                    onPageChange(newPage);
+                    return newPage;
+                  })}
                 >
                   이전
                 </button>

--- a/src/components/AllCardsComponent.tsx
+++ b/src/components/AllCardsComponent.tsx
@@ -257,7 +257,13 @@ export function AllCardsComponent({
                 <button 
                   class="pagination-btn"
                   disabled={localPage === totalPagesLocal - 1}
-                  onClick={() => { setLocalPage(p => Math.min(totalPagesLocal - 1, p + 1)); onPageChange(localPage + 1); }}
+                  onClick={() => {
+                    setLocalPage(p => {
+                      const newPage = Math.min(totalPagesLocal - 1, p + 1);
+                      onPageChange(newPage);
+                      return newPage;
+                    });
+                  }}
                 >
                   다음
                 </button>

--- a/src/components/DirectorySidebar.tsx
+++ b/src/components/DirectorySidebar.tsx
@@ -1,0 +1,122 @@
+import { h } from 'preact';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import type CardReviewPlugin from '../main';
+import type { CardData } from '../types';
+
+interface DirectorySidebarProps {
+	plugin: CardReviewPlugin;
+}
+
+export function DirectorySidebar({ plugin }: DirectorySidebarProps) {
+	const [newDir, setNewDir] = useState('');
+	const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set(['기본함']));
+
+	const directories = useMemo(() => plugin.getAllDirectories(), [plugin.cards]);
+
+	const dirToSources = useMemo(() => {
+		const map = new Map<string, Set<string>>();
+		for (const d of directories) map.set(d, new Set<string>());
+		for (const c of plugin.cards as CardData[]) {
+			const dir = (c.directory || '기본함');
+			if (!map.has(dir)) map.set(dir, new Set<string>());
+			if (c.source) map.get(dir)!.add(c.source);
+		}
+		return map;
+	}, [directories, plugin.cards]);
+
+    const sources = useMemo(() => {
+        const set = new Set<string>();
+        for (const c of plugin.cards as CardData[]) {
+            if (c.source) set.add(c.source);
+        }
+        return Array.from(set).sort();
+    }, [plugin.cards]);
+
+	const handleCreate = async () => {
+		const name = newDir.trim();
+		if (!name) return;
+		await plugin.createDirectory(name);
+		setNewDir('');
+	};
+
+	const handleDelete = async (name: string) => {
+		if (name === '기본함') return;
+		await plugin.deleteDirectory(name);
+		if (targetDir === name) setTargetDir('기본함');
+	};
+
+    useEffect(() => {
+        const onMove = async (e: any) => {
+            const { source, dir } = e.detail || {};
+            if (source && dir) {
+                await plugin.moveSourceToDirectory(source, dir);
+            }
+        };
+        window.addEventListener('card-review-move-source' as any, onMove);
+        return () => window.removeEventListener('card-review-move-source' as any, onMove);
+    }, [plugin]);
+
+	return (
+		<div class="directory-sidebar" style="padding:12px; display:flex; flex-direction:column; gap:12px;">
+			<div style="display:flex; gap:8px;">
+				<input
+					value={newDir}
+					onInput={(e: any) => setNewDir(e.currentTarget.value)}
+					placeholder="새 디렉토리 이름"
+					style="flex:1;"
+				/>
+				<button onClick={handleCreate}>추가</button>
+			</div>
+
+			<div style="display:flex; flex-direction:column; gap:6px; max-height:460px; overflow:auto;">
+				{directories.map((d) => {
+					const isExpanded = expandedDirs.has(d);
+					const dirSources = Array.from(dirToSources.get(d) || []);
+					return (
+						<div>
+							<div 
+								style="display:flex; align-items:center; justify-content:space-between; gap:8px; padding:6px 8px; border:1px solid var(--background-modifier-border); border-radius:6px; cursor:pointer;"
+								onClick={() => {
+									const next = new Set(expandedDirs);
+									if (isExpanded) next.delete(d); else next.add(d);
+									setExpandedDirs(next);
+								}}
+								onDragOver={(e: any) => e.preventDefault()}
+								onDrop={async (e: any) => {
+									try {
+										const data = e.dataTransfer.getData('text/plain');
+										const payload = JSON.parse(data);
+										if (payload && payload.type === 'source' && payload.source) {
+											await plugin.moveSourceToDirectory(payload.source, d);
+										}
+									} catch {}
+								}}
+							>
+								<span style="display:flex; align-items:center; gap:8px;">
+									<span style="width:10px; text-align:center;">{isExpanded ? '▾' : '▸'}</span>
+									<strong>{d}</strong>
+									<small style="color:var(--text-muted)">{dirSources.length}</small>
+								</span>
+								<button disabled={d==='기본함'} onClick={(e: any) => { e.stopPropagation(); handleDelete(d); }}>삭제</button>
+							</div>
+							{isExpanded && dirSources.length > 0 && (
+								<div style="margin-left:18px; display:flex; flex-direction:column; gap:6px; padding-top:4px;">
+									{dirSources.map(s => (
+										<div draggable={true}
+										 	onDragStart={(e: any) => {
+										 		e.dataTransfer.setData('text/plain', JSON.stringify({ type: 'source', source: s }));
+										 	}}
+										 	style="padding:6px 8px; border:1px dashed var(--background-modifier-border); border-radius:6px; cursor:grab;">
+											{s}
+										</div>
+									))}
+								</div>
+							)}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+

--- a/src/components/DirectorySidebar.tsx
+++ b/src/components/DirectorySidebar.tsx
@@ -56,14 +56,15 @@ export function DirectorySidebar({ plugin }: DirectorySidebarProps) {
 	};
 
     useEffect(() => {
-        const onMove = async (e: any) => {
-            const { source, dir } = e.detail || {};
+        const onMove = async (e: Event) => {
+            const detail = (e as CustomEvent).detail as { source?: string; dir?: string } | undefined;
+            const { source, dir } = detail || {};
             if (source && dir) {
                 await plugin.moveSourceToDirectory(source, dir);
             }
         };
-        window.addEventListener('card-review-move-source' as any, onMove);
-        return () => window.removeEventListener('card-review-move-source' as any, onMove);
+        window.addEventListener('card-review-move-source', onMove as EventListener);
+        return () => window.removeEventListener('card-review-move-source', onMove as EventListener);
     }, [plugin]);
 
     // 카드 이동 완료 시 UI 새로고침
@@ -72,8 +73,8 @@ export function DirectorySidebar({ plugin }: DirectorySidebarProps) {
             setRefreshTrigger(prev => prev + 1);
         };
         
-        window.addEventListener('card-review-move-complete' as any, handleMoveComplete);
-        return () => window.removeEventListener('card-review-move-complete' as any, handleMoveComplete);
+        window.addEventListener('card-review-move-complete', handleMoveComplete);
+        return () => window.removeEventListener('card-review-move-complete', handleMoveComplete);
     }, []);
 
 	return (

--- a/src/main.ts
+++ b/src/main.ts
@@ -396,7 +396,7 @@ export default class CardReviewPlugin extends Plugin {
 
 	async loadCards() {
 		const data = await this.loadData();
-    this.cards = (data?.cards || []).map((card: any) => ({
+    this.cards = (data?.cards || []).map((card: CardData) => ({
 			...card,
 			// 기존 카드에 directory 필드가 없으면 기본값 설정
 			directory: card.directory || this.getDirectoryFromPath(card.source)

--- a/src/main.ts
+++ b/src/main.ts
@@ -433,7 +433,8 @@ export default class CardReviewPlugin extends Plugin {
 	}
 
 	getTotalPages(itemsPerPage: number = 50): number {
-		return Math.ceil(this.cards.length / itemsPerPage);
+		const total = this.getAllCards().length;
+		return Math.max(1, Math.ceil(total / itemsPerPage));
 	}
 
 	// 배열을 랜덤하게 섞는 메서드 (Fisher-Yates 알고리즘)

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface WindowEventMap {
+    'card-review-move-source': CustomEvent<{ source: string; dir: string }>;
+    'card-review-move-complete': Event;
+  }
+}
+
+export {};

--- a/src/views/AllCardsView.ts
+++ b/src/views/AllCardsView.ts
@@ -1,6 +1,7 @@
 import { ItemView, WorkspaceLeaf } from 'obsidian';
 import { h, render } from 'preact';
 import { AllCardsComponent } from '../components/AllCardsComponent';
+import { ITEMS_PER_PAGE } from '../types';
 import type CardReviewPlugin from '../main';
 
 export const ALL_CARDS_VIEW_TYPE = 'all-cards-view';
@@ -8,8 +9,7 @@ export const ALL_CARDS_VIEW_TYPE = 'all-cards-view';
 export class AllCardsView extends ItemView {
   plugin: CardReviewPlugin;
   private currentPage: number = 0;
-  private readonly itemsPerPage: number = 50;
-  private refreshInterval: number | null = null;
+  private readonly itemsPerPage: number = ITEMS_PER_PAGE;
   private isRendering: boolean = false;
 
   constructor(leaf: WorkspaceLeaf, plugin: CardReviewPlugin) {
@@ -31,21 +31,10 @@ export class AllCardsView extends ItemView {
 
   async onOpen() {
     this.renderCards();
-    
-    // 자동 새로고침 타이머 시작 (5초마다)
-    this.refreshInterval = window.setInterval(() => {
-      if (!this.isRendering) {
-        this.refresh();
-      }
-    }, 5000);
   }
 
   async onClose() {
-    // 자동 새로고침 타이머 정리
-    if (this.refreshInterval) {
-      window.clearInterval(this.refreshInterval);
-      this.refreshInterval = null;
-    }
+    // 현재는 폴링을 사용하지 않음
   }
 
   renderCards() {
@@ -57,7 +46,6 @@ export class AllCardsView extends ItemView {
     
     try {
       const container = this.containerEl.children[1];
-      container.empty();
 
     const handleDeleteCard = async (cardId: string) => {
       try {
@@ -69,7 +57,7 @@ export class AllCardsView extends ItemView {
           this.currentPage--;
         }
         
-        this.renderCards(); // 목록 새로고침
+        this.renderCards(); // 목록 새로고침 (페이지 조정 후 반영)
       } catch (error) {
         console.error('카드 삭제 중 오류:', error);
       }

--- a/src/views/AllCardsView.ts
+++ b/src/views/AllCardsView.ts
@@ -45,7 +45,10 @@ export class AllCardsView extends ItemView {
     this.isRendering = true;
     
     try {
-      const container = this.containerEl.children[1];
+      const container = this.contentEl;
+      container.empty();
+      // 안전한 렌더 타깃 생성
+      const root = container.createDiv({ cls: 'all-cards-root' });
 
     const handleDeleteCard = async (cardId: string) => {
       try {
@@ -89,18 +92,8 @@ export class AllCardsView extends ItemView {
       this.renderCards();
     };
 
-    const handleMoveSource = async (source: string, dir: string) => {
-      try {
-        if (!source) {
-          await this.plugin.createDirectory(dir);
-        } else {
-          await this.plugin.moveSourceToDirectory(source, dir);
-        }
-        this.renderCards();
-      } catch (e) {
-        console.error('소스 이동 오류:', e);
-      }
-    };
+    // 사이드바로 이동 기능을 이전했으므로, 이 핸들러는 유지하되 호출되지 않음
+    const handleMoveSource = async (source: string, dir: string) => {};
 
     // 현재 페이지의 카드들만 가져오기
     const currentCards = this.plugin.getCardsByPage(this.currentPage, this.itemsPerPage);
@@ -113,14 +106,13 @@ export class AllCardsView extends ItemView {
         allCards,
         onDeleteCard: handleDeleteCard,
         onResetAllCards: handleResetAllCards,
-        onMoveSource: handleMoveSource,
         onPageChange: handlePageChange,
         currentPage: this.currentPage,
         totalPages: totalPages,
         app: this.app,
         plugin: this.plugin
       }),
-      container
+      root
     );
     } catch (error) {
       console.error('AllCardsView 렌더링 오류:', error);

--- a/src/views/AllCardsView.ts
+++ b/src/views/AllCardsView.ts
@@ -85,18 +85,35 @@ export class AllCardsView extends ItemView {
 
     const handlePageChange = (page: number) => {
       this.currentPage = page;
+      // 상위에서 전체 렌더는 유지하되, 빈번 호출 방지
       this.renderCards();
+    };
+
+    const handleMoveSource = async (source: string, dir: string) => {
+      try {
+        if (!source) {
+          await this.plugin.createDirectory(dir);
+        } else {
+          await this.plugin.moveSourceToDirectory(source, dir);
+        }
+        this.renderCards();
+      } catch (e) {
+        console.error('소스 이동 오류:', e);
+      }
     };
 
     // 현재 페이지의 카드들만 가져오기
     const currentCards = this.plugin.getCardsByPage(this.currentPage, this.itemsPerPage);
     const totalPages = this.plugin.getTotalPages(this.itemsPerPage);
+    const allCards = (this.plugin as any).cards || [];
 
     render(
       h(AllCardsComponent, {
         cards: currentCards,
+        allCards,
         onDeleteCard: handleDeleteCard,
         onResetAllCards: handleResetAllCards,
+        onMoveSource: handleMoveSource,
         onPageChange: handlePageChange,
         currentPage: this.currentPage,
         totalPages: totalPages,

--- a/src/views/AllCardsView.ts
+++ b/src/views/AllCardsView.ts
@@ -11,6 +11,7 @@ export class AllCardsView extends ItemView {
   private currentPage: number = 0;
   private readonly itemsPerPage: number = ITEMS_PER_PAGE;
   private isRendering: boolean = false;
+  private selectedDirectory: string = '기본함';
 
   constructor(leaf: WorkspaceLeaf, plugin: CardReviewPlugin) {
     super(leaf);
@@ -92,6 +93,11 @@ export class AllCardsView extends ItemView {
       this.renderCards();
     };
 
+    const handleDirectorySelect = (dir: string) => {
+      this.selectedDirectory = dir;
+      this.renderCards();
+    };
+
     // 사이드바로 이동 기능을 이전했으므로, 이 핸들러는 유지하되 호출되지 않음
     const handleMoveSource = async (source: string, dir: string) => {};
 
@@ -110,7 +116,9 @@ export class AllCardsView extends ItemView {
         currentPage: this.currentPage,
         totalPages: totalPages,
         app: this.app,
-        plugin: this.plugin
+        plugin: this.plugin,
+        selectedDirectory: this.selectedDirectory,
+        onDirectorySelect: handleDirectorySelect
       }),
       root
     );

--- a/src/views/DirectorySidebarView.ts
+++ b/src/views/DirectorySidebarView.ts
@@ -1,0 +1,30 @@
+import { ItemView, WorkspaceLeaf } from 'obsidian';
+import { h, render } from 'preact';
+import { DirectorySidebar } from '../components/DirectorySidebar';
+import type CardReviewPlugin from '../main';
+
+export const DIRECTORY_SIDEBAR_VIEW = 'card-directory-sidebar';
+
+export class DirectorySidebarView extends ItemView {
+	plugin: CardReviewPlugin;
+
+	constructor(leaf: WorkspaceLeaf, plugin: CardReviewPlugin) {
+		super(leaf);
+		this.plugin = plugin;
+	}
+
+	getViewType() { return DIRECTORY_SIDEBAR_VIEW; }
+	getDisplayText() { return '카드 디렉토리'; }
+	getIcon() { return 'folders'; }
+
+	onOpen() {
+		const container = this.contentEl;
+		container.empty();
+		render(h(DirectorySidebar, { plugin: this.plugin }), container);
+	}
+
+	onClose() {
+		this.contentEl.empty();
+	}
+}
+

--- a/styles.css
+++ b/styles.css
@@ -205,13 +205,14 @@
 /* 폴더 그리드(정사각형 타일) */
 .directory-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+	grid-template-columns: repeat(auto-fill, 140px);
 	gap: 16px;
 	margin-top: 20px;
+	justify-content: start;
 }
 
 .directory-tile {
-	aspect-ratio: 1;
+	height: 140px;
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 12px;
@@ -236,6 +237,17 @@
 	background: var(--interactive-accent);
 	color: white;
 	border-color: var(--interactive-accent);
+}
+
+.directory-tile.create {
+	background: transparent;
+	border: 2px dashed var(--background-modifier-border);
+	color: var(--text-muted);
+}
+
+.directory-tile.create:hover {
+	border-color: var(--interactive-accent);
+	color: var(--interactive-accent);
 }
 
 .directory-title {

--- a/styles.css
+++ b/styles.css
@@ -210,6 +210,9 @@
 	margin-top: 20px;
 	justify-content: start;
 	justify-items: start;
+    position: relative;
+    z-index: 2;
+    pointer-events: auto;
 }
 
 .directory-tile {
@@ -310,6 +313,8 @@
 	display: flex;
 	flex-direction: column;
 	gap: 15px;
+    position: relative;
+    z-index: 1;
 }
 
 .card-item {
@@ -423,6 +428,7 @@
 	text-align: center;
 	padding: 40px 20px;
 	color: var(--text-muted);
+    pointer-events: none;
 }
 
 .empty-state p {

--- a/styles.css
+++ b/styles.css
@@ -205,14 +205,14 @@
 /* 폴더 그리드(정사각형 타일) */
 .directory-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, 140px);
+	grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
 	gap: 16px;
 	margin-top: 20px;
 	justify-content: start;
+	justify-items: start;
 }
 
 .directory-tile {
-	height: 140px;
 	background: var(--background-secondary);
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 12px;
@@ -224,6 +224,10 @@
 	transition: all 0.2s ease;
 	padding: 16px;
 	text-align: center;
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 140px;
+	aspect-ratio: 1;
 }
 
 .directory-tile:hover {

--- a/styles.css
+++ b/styles.css
@@ -337,27 +337,35 @@
 	font-size: 0.85em;
 }
 
+
 .card-status {
 	display: flex;
 	align-items: center;
 }
 
+.status-kept,
+.status-pending {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 6px 10px;
+	border-radius: 9999px;
+	font-size: 12px;
+	line-height: 1;
+	font-weight: 700;
+	white-space: nowrap;
+	min-height: 24px;
+	min-width: 64px;
+}
+
 .status-kept {
 	background: var(--color-green);
 	color: white;
-	padding: 4px 8px;
-	border-radius: 4px;
-	font-size: 0.8em;
-	font-weight: bold;
 }
 
 .status-pending {
 	background: var(--color-orange);
 	color: white;
-	padding: 4px 8px;
-	border-radius: 4px;
-	font-size: 0.8em;
-	font-weight: bold;
 }
 
 .card-delete-btn {


### PR DESCRIPTION
#2
<img width="2239" height="1322" alt="image" src="https://github.com/user-attachments/assets/8556046f-1390-454b-9ef0-c2571f7a6bc5" />
오른쪽 사이드 바에서 디렉토리 추가 및 삭제가 가능하고 노트 이동이 가능하게 만듦
[모든 카드 보기] 에서 해당 디렉토리를 선택하여 열람할 수 있고 
<img width="829" height="590" alt="image" src="https://github.com/user-attachments/assets/29d546d0-517a-4238-9013-5b161fba3955" />
카드 리뷰에도 이를 반영 했음 이제 카드 리뷰를 시작할 때 디렉토리 별로 실행이 가능함 